### PR TITLE
wfprev-697. endorsement and approval last update time/user are separete with project fiscal last update time/user

### DIFF
--- a/client/wfprev-war/src/main/angular/src/app/components/edit-project/endorsement-approval/endorsement-approval.component.html
+++ b/client/wfprev-war/src/main/angular/src/app/components/edit-project/endorsement-approval/endorsement-approval.component.html
@@ -73,6 +73,10 @@
           </wfprev-textarea>
         </div>
       </div>
+      <wfprev-timestamp
+        [updateDate]="fiscal?.endorseApprUpdatedTimestamp"
+        [updateUser]="fiscal?.endorseApprUpdateUserid">
+      </wfprev-timestamp>
     </form>
   </wfprev-details-container>
 </ng-container>

--- a/client/wfprev-war/src/main/angular/src/app/components/edit-project/endorsement-approval/endorsement-approval.component.ts
+++ b/client/wfprev-war/src/main/angular/src/app/components/edit-project/endorsement-approval/endorsement-approval.component.ts
@@ -12,7 +12,9 @@ import { DatePickerComponent } from 'src/app/components/shared/date-picker/date-
 import { DetailsContainerComponent } from 'src/app/components/shared/details-container/details-container.component';
 import { ReadOnlyFieldComponent } from 'src/app/components/shared/read-only-field/read-only-field.component';
 import { TextareaComponent } from 'src/app/components/shared/textarea/textarea.component';
+import { TimestampComponent } from 'src/app/components/shared/timestamp/timestamp.component';
 import { EndorsementCode, FiscalStatuses } from 'src/app/utils/constants';
+import { getLocalIsoTimestamp } from 'src/app/utils/tools';
 
 @Component({
   selector: 'wfprev-endorsement-approval',
@@ -30,7 +32,8 @@ import { EndorsementCode, FiscalStatuses } from 'src/app/utils/constants';
     CheckboxComponent,
     DatePickerComponent,
     ReadOnlyFieldComponent,
-    TextareaComponent
+    TextareaComponent,
+    TimestampComponent
   ],
   templateUrl: './endorsement-approval.component.html',
   styleUrl: './endorsement-approval.component.scss'
@@ -39,6 +42,7 @@ export class EndorsementApprovalComponent implements OnChanges {
 
   @Input() fiscal!: ProjectFiscal;
   @Input() currentUser!: string;
+  @Input() currentIdir!: string;
   @Output() saveEndorsement = new EventEmitter<ProjectFiscal>();
 
   endorsementApprovalForm = new FormGroup({
@@ -118,13 +122,14 @@ export class EndorsementApprovalComponent implements OnChanges {
       currentStatusCode !== FiscalStatuses.DRAFT &&
       currentStatusCode !== FiscalStatuses.PROPOSED;
 
+    const currentIso = getLocalIsoTimestamp();
     const updatedFiscal: ProjectFiscal = {
       ...this.fiscal,
 
       // Endorsement logic
       endorserName: formValue.endorseFiscalActivity ? this.currentUser : undefined,
       endorsementTimestamp: formValue.endorseFiscalActivity && formValue.endorsementDate
-        ? new Date(formValue.endorsementDate).toISOString()
+        ? getLocalIsoTimestamp(formValue.endorsementDate)
         : undefined,
       endorsementCode: formValue.endorseFiscalActivity
         ? { endorsementCode: EndorsementCode.ENDORSED }
@@ -143,6 +148,8 @@ export class EndorsementApprovalComponent implements OnChanges {
       planFiscalStatusCode: shouldResetToPrepared
         ? { planFiscalStatusCode: FiscalStatuses.DRAFT }
         : this.fiscal.planFiscalStatusCode,
+      endorseApprUpdateUserid: this.currentIdir,
+      endorseApprUpdatedTimestamp: currentIso,
     };
 
     this.saveEndorsement.emit(updatedFiscal);

--- a/client/wfprev-war/src/main/angular/src/app/components/edit-project/project-fiscals/project-fiscals.component.html
+++ b/client/wfprev-war/src/main/angular/src/app/components/edit-project/project-fiscals/project-fiscals.component.html
@@ -294,8 +294,8 @@
 
                 </form>
                 <wfprev-timestamp
-                  [updateDate]="projectFiscals[i]?.updateDate"
-                  [updateUser]="projectFiscals[i]?.updateUser">
+                  [updateDate]="projectFiscals[i]?.submissionTimestamp"
+                  [updateUser]="projectFiscals[i]?.submittedByUserUserid">
                 </wfprev-timestamp>
                 <div class="fiscal-footer">
                   <div class="footer-button-row">
@@ -313,7 +313,7 @@
                 <wfprev-activities class="activities-panel" [fiscalGuid]="currentFiscalGuid" (boundariesUpdated)="onBoundariesChanged()"></wfprev-activities>
                 <div class="fiscal-and-endorsement">
                   <wfprev-fiscal-map class="fiscal-map-panel" *ngIf="selectedTabIndex === i" [fiscalGuid]="selectedTabIndex" [selectedFiscalYear]="projectFiscals[selectedTabIndex]?.fiscalYear"  #fiscalMapRef></wfprev-fiscal-map>
-                  <wfprev-endorsement-approval [fiscal]="projectFiscals[i]" [currentUser]="currentUser" (saveEndorsement)="onSaveEndorsement($event)"></wfprev-endorsement-approval>
+                  <wfprev-endorsement-approval [fiscal]="projectFiscals[i]" [currentUser]="currentUser" [currentIdir]="currentIdir" (saveEndorsement)="onSaveEndorsement($event)"></wfprev-endorsement-approval>
                 </div>
               </div>
             </mat-accordion>

--- a/client/wfprev-war/src/main/angular/src/app/components/edit-project/project-fiscals/project-fiscals.component.spec.ts
+++ b/client/wfprev-war/src/main/angular/src/app/components/edit-project/project-fiscals/project-fiscals.component.spec.ts
@@ -13,6 +13,7 @@ import { PlanFiscalStatusIcons } from 'src/app/utils/tools';
 import { EndorsementCode, ModalMessages, ModalTitles } from 'src/app/utils/constants';
 import { TokenService } from 'src/app/services/token.service';
 import { ProjectFiscal } from 'src/app/components/models';
+import * as Tools from 'src/app/utils/tools';
 
 const mockProjectService = {
   getProjectFiscalsByProjectGuid: jasmine.createSpy('getProjectFiscalsByProjectGuid').and.returnValue(
@@ -67,7 +68,9 @@ describe('ProjectFiscalsComponent', () => {
       imports: [BrowserAnimationsModule],
       declarations: [MockFiscalMapComponent, MockActivitiesComponent],
       providers: [
-        { provide: TokenService, useValue: { getUserFullName: jasmine.createSpy('getUserFullName').and.returnValue('Test User') } },
+        { provide: TokenService, useValue: { getUserFullName: jasmine.createSpy('getUserFullName').and.returnValue('Test User'),
+          getIdir: jasmine.createSpy('getIdir').and.returnValue('IDIR123')
+         } },
         {
           provide: ActivatedRoute,
           useValue: {
@@ -839,4 +842,25 @@ describe('ProjectFiscalsComponent', () => {
       { duration: 5000, panelClass: 'snackbar-error' }
     );
   });
+
+  afterEach(() => {
+    try { jasmine.clock().uninstall(); } catch {}
+  });
+  it('should build submission fields with currentIdir and local ISO timestamp', () => {
+    jasmine.clock().install();
+    jasmine.clock().mockDate(new Date('2025-08-08T19:34:56.000Z'));
+
+    component.currentIdir = 'IDIR123';
+
+    const expectedTs = Tools.getLocalIsoTimestamp();
+    const result = component.buildSubmissionFields();
+
+    expect(result).toEqual({
+      submittedByUserUserid: 'IDIR123',
+      submissionTimestamp: expectedTs,
+    });
+
+    jasmine.clock().uninstall();
+  });
+
 });

--- a/client/wfprev-war/src/main/angular/src/app/components/models.ts
+++ b/client/wfprev-war/src/main/angular/src/app/components/models.ts
@@ -65,7 +65,6 @@ export interface ProjectFiscal {
   fiscalActualCostPerHaAmt: number;
   firstNationsDelivPartInd: boolean;
   firstNationsEngagementInd: boolean;
-
   projectPlanFiscalGuid?: string;
   projectFiscalDescription?: string;
   businessAreaComment?: string;
@@ -100,6 +99,10 @@ export interface ProjectFiscal {
   delayRationale?: string;
   abandonedRationale?: string;
   lastProgressUpdateTimestamp?: string;
+  endorseApprUpdateName?: string;
+  endorseApprUpdateUserGuid?: string;
+  endorseApprUpdateUserid?: string;
+  endorseApprUpdatedTimestamp?: string;
 }
 
 

--- a/client/wfprev-war/src/main/angular/src/app/services/token.service.spec.ts
+++ b/client/wfprev-war/src/main/angular/src/app/services/token.service.spec.ts
@@ -359,6 +359,15 @@ describe('getUserFullName', () => {
     });
   });
 
+  describe('getIdir', () => {
+    it('should return the userId from tokenDetails', () => {
+      service['tokenDetails'] = { userId: 'IDIR123' };
+      expect(service.getIdir()).toBe('IDIR123');
+    });
 
-
+    it('should return undefined if tokenDetails.userId is not set', () => {
+      service['tokenDetails'] = {};
+      expect(service.getIdir()).toBeUndefined();
+    });
+  });
 });

--- a/client/wfprev-war/src/main/angular/src/app/services/token.service.ts
+++ b/client/wfprev-war/src/main/angular/src/app/services/token.service.ts
@@ -233,6 +233,11 @@ export class TokenService {
     return `${first} ${last}`.trim();
   }
 
+  public getIdir(): string {
+    const idir = this.tokenDetails.userId;
+    return idir;
+  }
+
 
   public doesUserHaveApplicationPermissions(scopes?: string[]): boolean {
     if (this.tokenDetails?.scope?.length > 0 && scopes?.length) {

--- a/client/wfprev-war/src/main/angular/src/app/utils/tools.spec.ts
+++ b/client/wfprev-war/src/main/angular/src/app/utils/tools.spec.ts
@@ -1,5 +1,5 @@
 import { FiscalYearColors } from 'src/app/utils/constants';
-import { parseLatLong, validateLatLong, formatLatLong, trimLatLong, getFiscalYearDisplay, getFiscalYearColor } from './tools';
+import { parseLatLong, validateLatLong, formatLatLong, trimLatLong, getFiscalYearDisplay, getFiscalYearColor, LOCAL_ISO_FORMAT, getLocalIsoTimestamp } from './tools';
 
 describe('Latitude/Longitude Utilities', () => {
   describe('parseLatLong', () => {
@@ -104,6 +104,29 @@ describe('Latitude/Longitude Utilities', () => {
 
     it('should return future color for fiscal activity greater than current year', () => {
       expect(getFiscalYearColor(2025, currentYear)).toBe(FiscalYearColors.future);
+    });
+  });
+
+    
+  describe('LOCAL_ISO_FORMAT and getLocalIsoTimestamp', () => {
+
+    it('should format a given date in the expected en-CA local ISO format', () => {
+      const date = new Date('2025-08-08T11:20:30Z');
+      const formatted = LOCAL_ISO_FORMAT.format(date);
+      expect(formatted).toMatch(/^\d{4}-\d{2}-\d{2}, \d{2}:\d{2}:\d{2}$/);
+    });
+
+    it('should return a timestamp string with "T" separator for given date', () => {
+      const date = new Date('2025-08-08T11:20:30Z');
+      const ts = getLocalIsoTimestamp(date);
+      expect(ts).toContain('T');
+      expect(ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/);
+    });
+
+    it('should default to current date/time when no date is provided', () => {
+      const ts = getLocalIsoTimestamp();
+      expect(typeof ts).toBe('string');
+      expect(ts).toMatch(/T\d{2}:\d{2}:\d{2}$/);
     });
   });
 });

--- a/client/wfprev-war/src/main/angular/src/app/utils/tools.ts
+++ b/client/wfprev-war/src/main/angular/src/app/utils/tools.ts
@@ -1,6 +1,5 @@
 import L from "leaflet";
 import { FiscalYearColors, PlanFiscalStatus } from "src/app/utils/constants";
-import * as Tools from 'src/app/utils/tools';
 
 // Parse latitude/longitude string from various formats
 export function parseLatLong(latLong: string): { latitude: number; longitude: number } | null {
@@ -204,24 +203,3 @@ export function getLocalIsoTimestamp(date?: Date): string {
     .replace(',', '')
     .replace(' ', 'T');
 }
-
-describe('LOCAL_ISO_FORMAT and getLocalIsoTimestamp', () => {
-  it('should format a given date in the expected en-CA local ISO format', () => {
-    const date = new Date('2025-08-08T11:20:30Z');
-    const formatted = Tools.LOCAL_ISO_FORMAT.format(date);
-    expect(formatted).toMatch(/^\d{4}-\d{2}-\d{2}, \d{2}:\d{2}:\d{2}$/);
-  });
-
-  it('should return a timestamp string with "T" separator for given date', () => {
-    const date = new Date('2025-08-08T11:20:30Z');
-    const ts = Tools.getLocalIsoTimestamp(date);
-    expect(ts).toContain('T');
-    expect(ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/);
-  });
-
-  it('should default to current date/time when no date is provided', () => {
-    const ts = Tools.getLocalIsoTimestamp();
-    expect(typeof ts).toBe('string');
-    expect(ts).toMatch(/T\d{2}:\d{2}:\d{2}$/);
-  });
-});

--- a/client/wfprev-war/src/main/angular/src/app/utils/tools.ts
+++ b/client/wfprev-war/src/main/angular/src/app/utils/tools.ts
@@ -1,5 +1,6 @@
 import L from "leaflet";
 import { FiscalYearColors, PlanFiscalStatus } from "src/app/utils/constants";
+import * as Tools from 'src/app/utils/tools';
 
 // Parse latitude/longitude string from various formats
 export function parseLatLong(latLong: string): { latitude: number; longitude: number } | null {
@@ -183,3 +184,44 @@ export function getFiscalYearColor(fiscalYear: number, currentFiscalYear: number
   if (fiscalYear === currentFiscalYear) return FiscalYearColors.present;
   return FiscalYearColors.future;
 }
+
+
+export const LOCAL_ISO_FORMAT = Intl.DateTimeFormat('en-CA', {
+  timeZone: undefined,
+  hour12: false,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit'
+});
+
+export function getLocalIsoTimestamp(date?: Date): string {
+  // Example: 2025-08-08T11:20:30
+  const targetDate = date ?? new Date();
+  return LOCAL_ISO_FORMAT.format(targetDate)
+    .replace(',', '')
+    .replace(' ', 'T');
+}
+
+describe('LOCAL_ISO_FORMAT and getLocalIsoTimestamp', () => {
+  it('should format a given date in the expected en-CA local ISO format', () => {
+    const date = new Date('2025-08-08T11:20:30Z');
+    const formatted = Tools.LOCAL_ISO_FORMAT.format(date);
+    expect(formatted).toMatch(/^\d{4}-\d{2}-\d{2}, \d{2}:\d{2}:\d{2}$/);
+  });
+
+  it('should return a timestamp string with "T" separator for given date', () => {
+    const date = new Date('2025-08-08T11:20:30Z');
+    const ts = Tools.getLocalIsoTimestamp(date);
+    expect(ts).toContain('T');
+    expect(ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/);
+  });
+
+  it('should default to current date/time when no date is provided', () => {
+    const ts = Tools.getLocalIsoTimestamp();
+    expect(typeof ts).toBe('string');
+    expect(ts).toMatch(/T\d{2}:\d{2}:\d{2}$/);
+  });
+});

--- a/server/wfprev-api/src/main/java/ca/bc/gov/nrs/wfprev/data/assemblers/ProjectFiscalResourceAssembler.java
+++ b/server/wfprev-api/src/main/java/ca/bc/gov/nrs/wfprev/data/assemblers/ProjectFiscalResourceAssembler.java
@@ -100,6 +100,10 @@ public class ProjectFiscalResourceAssembler extends RepresentationModelAssembler
         model.setUpdateUser(entity.getUpdateUser());
         model.setCreateDate(entity.getCreateDate());
         model.setUpdateDate(entity.getUpdateDate());
+        model.setEndorseApprUpdateName(entity.getEndorseApprUpdateName());
+        model.setEndorseApprUpdateUserGuid(entity.getEndorseApprUpdateUserGuid());
+        model.setEndorseApprUpdateUserid(entity.getEndorseApprUpdateUserid());
+        model.setEndorseApprUpdatedTimestamp(entity.getEndorseApprUpdatedTimestamp());
 
         return model;
     }
@@ -182,6 +186,10 @@ public class ProjectFiscalResourceAssembler extends RepresentationModelAssembler
         entity.setCreateDate(model.getCreateDate());
         entity.setUpdateUser(model.getUpdateUser());
         entity.setUpdateDate(model.getUpdateDate());
+        entity.setEndorseApprUpdateName(model.getEndorseApprUpdateName());
+        entity.setEndorseApprUpdateUserGuid(model.getEndorseApprUpdateUserGuid());
+        entity.setEndorseApprUpdateUserid(model.getEndorseApprUpdateUserid());
+        entity.setEndorseApprUpdatedTimestamp(model.getEndorseApprUpdatedTimestamp());
         return entity;
     }
 
@@ -288,6 +296,14 @@ public class ProjectFiscalResourceAssembler extends RepresentationModelAssembler
                 nonNullOrDefault(projectFiscalModel.getAbandonedRationale(), existingEntity.getAbandonedRationale()));
         existingEntity.setLastProgressUpdateTimestamp(
                 nonNullOrDefault(projectFiscalModel.getLastProgressUpdateTimestamp(), existingEntity.getLastProgressUpdateTimestamp()));
+        existingEntity.setEndorseApprUpdateName(
+                nonNullOrDefault(projectFiscalModel.getEndorseApprUpdateName(), existingEntity.getEndorseApprUpdateName()));
+        existingEntity.setEndorseApprUpdateUserGuid(
+                nonNullOrDefault(projectFiscalModel.getEndorseApprUpdateUserGuid(), existingEntity.getEndorseApprUpdateUserGuid()));
+        existingEntity.setEndorseApprUpdateUserid(
+                nonNullOrDefault(projectFiscalModel.getEndorseApprUpdateUserid(), existingEntity.getEndorseApprUpdateUserid()));
+        existingEntity.setEndorseApprUpdatedTimestamp(
+                nonNullOrDefault(projectFiscalModel.getEndorseApprUpdatedTimestamp(), existingEntity.getEndorseApprUpdatedTimestamp()));
 
         return existingEntity;
     }

--- a/server/wfprev-api/src/main/java/ca/bc/gov/nrs/wfprev/data/entities/ProjectFiscalEntity.java
+++ b/server/wfprev-api/src/main/java/ca/bc/gov/nrs/wfprev/data/entities/ProjectFiscalEntity.java
@@ -220,4 +220,16 @@ public class ProjectFiscalEntity implements Serializable {
     @NotNull
     @Column(name = "update_date", nullable = false)
     private Date updateDate;
+
+    @Column(name = "endorse_appr_update_name", length = 100)
+    private String endorseApprUpdateName;
+
+    @Column(name = "endorse_appr_update_user_guid", length = 100)
+    private String endorseApprUpdateUserGuid;
+
+    @Column(name = "endorse_appr_update_userid", length = 100)
+    private String endorseApprUpdateUserid;
+
+    @Column(name = "endorse_appr_updated_timestamp")
+    private Date endorseApprUpdatedTimestamp;
 }

--- a/server/wfprev-api/src/main/java/ca/bc/gov/nrs/wfprev/data/models/ProjectFiscalModel.java
+++ b/server/wfprev-api/src/main/java/ca/bc/gov/nrs/wfprev/data/models/ProjectFiscalModel.java
@@ -76,4 +76,8 @@ public class ProjectFiscalModel extends CommonModel<ProjectFiscalModel> {
     private String delayRationale;
     private String abandonedRationale;
     private Date lastProgressUpdateTimestamp;
+    private String endorseApprUpdateName;
+    private String endorseApprUpdateUserGuid;
+    private String endorseApprUpdateUserid;
+    private Date endorseApprUpdatedTimestamp;
 }

--- a/server/wfprev-api/src/test/java/ca/bc/gov/nrs/wfprev/data/assemblers/ProjectFiscalResourceAssemblerTest.java
+++ b/server/wfprev-api/src/test/java/ca/bc/gov/nrs/wfprev/data/assemblers/ProjectFiscalResourceAssemblerTest.java
@@ -39,6 +39,10 @@ class ProjectFiscalResourceAssemblerTest {
                 .createDate(new Date())
                 .updateUser("tester2")
                 .updateDate(new Date())
+                .endorseApprUpdateName("endorser name")
+                .endorseApprUpdateUserGuid("user-guid-123")
+                .endorseApprUpdateUserid("idir123")
+                .endorseApprUpdatedTimestamp(new Date())
                 .build();
 
         // Act
@@ -55,6 +59,10 @@ class ProjectFiscalResourceAssemblerTest {
         assertEquals(model.getProjectFiscalName(), entity.getProjectFiscalName());
         assertEquals(model.getIsApprovedInd(), entity.getIsApprovedInd());
         assertEquals(model.getIsDelayedInd(), entity.getIsDelayedInd());
+        assertEquals(model.getEndorseApprUpdateName(), entity.getEndorseApprUpdateName());
+        assertEquals(model.getEndorseApprUpdateUserGuid(), entity.getEndorseApprUpdateUserGuid());
+        assertEquals(model.getEndorseApprUpdateUserid(), entity.getEndorseApprUpdateUserid());
+        assertEquals(model.getEndorseApprUpdatedTimestamp(), entity.getEndorseApprUpdatedTimestamp());
     }
 
     @Test
@@ -90,6 +98,10 @@ class ProjectFiscalResourceAssemblerTest {
         assertEquals(entity.getProjectFiscalName(), model.getProjectFiscalName(), "ProjectFiscalName should match");
         assertEquals(entity.getIsApprovedInd(), model.getIsApprovedInd(), "IsApprovedInd should match");
         assertEquals(entity.getIsDelayedInd(), model.getIsDelayedInd(), "IsDelayedInd should match");
+        assertEquals(entity.getEndorseApprUpdateName(), model.getEndorseApprUpdateName());
+        assertEquals(entity.getEndorseApprUpdateUserGuid(), model.getEndorseApprUpdateUserGuid());
+        assertEquals(entity.getEndorseApprUpdateUserid(), model.getEndorseApprUpdateUserid());
+        assertEquals(entity.getEndorseApprUpdatedTimestamp(), model.getEndorseApprUpdatedTimestamp());
     }
 
     @Test


### PR DESCRIPTION
Fiscal Activity Card will use it own timestamp & idir,
Endorsmeent/ Approval card will use it own timestamp & idir.  
So Endorsmeent/ Approval wont affect fiscal activity's "last update". Vice versa
https://apps.nrs.gov.bc.ca/int/jira/browse/WFPREV-697
<img width="531" height="635" alt="image" src="https://github.com/user-attachments/assets/557c2dbf-84d9-4791-be1b-f4d6c8f31837" />
<img width="1686" height="1204" alt="image" src="https://github.com/user-attachments/assets/37442d7b-0ff5-485c-b99d-5627d576f00e" />


