### PR TITLE
Wfprev 677- Lazy loading with order by and pagination. Map portion use projectLocation endpoint with filters. Insert pinned item to the list by condition then reorder the list.

### DIFF
--- a/client/wfprev-war/src/main/angular/src/app/components/list-panel/projects-list/projects-list.component.html
+++ b/client/wfprev-war/src/main/angular/src/app/components/list-panel/projects-list/projects-list.component.html
@@ -30,14 +30,19 @@
     </div>
     <div class="result-count">
       <!-- Result Count -->
-      <span>{{ allProjects.length }} Results</span>
+      <span>{{ totalItems }} Results</span>
     </div>
   </div>
 
-  <div class="list-contents">
+  <div class="list-contents" (scroll)="onScroll($event)">
     <mat-accordion [multi]="true">
-      <mat-expansion-panel hideToggle *ngFor="let project of displayedProjects?.length ? displayedProjects : []" [expanded]="expandedPanels[project.projectGuid]" 
-        [ngClass]="{ 'selected-project': selectedProjectGuid === project.projectGuid }" #panel="matExpansionPanel">
+    <mat-expansion-panel
+      hideToggle
+      *ngFor="let project of displayedProjects; trackBy: this['trackByProjectGuid']"
+      [expanded]="expandedPanels[project.projectGuid]"
+      [ngClass]="{ 'selected-project': selectedProjectGuid === project.projectGuid }"
+      #panel="matExpansionPanel"
+      [attr.data-guid]="project.projectGuid">
         <mat-expansion-panel-header class="expansion-panel-header" (click)="onHeaderClick($event, project)">
           <mat-panel-title class="project-title">
             <div class="custom-indicator">
@@ -138,5 +143,12 @@
         </div>
       </mat-expansion-panel>
     </mat-accordion>
+    <div class="spinner-container" *ngIf="isLoading">
+      <mat-progress-spinner
+        mode="indeterminate"
+        diameter="36"
+        color="primary">
+      </mat-progress-spinner>
+    </div>
   </div>
 </div>

--- a/client/wfprev-war/src/main/angular/src/app/components/list-panel/projects-list/projects-list.component.scss
+++ b/client/wfprev-war/src/main/angular/src/app/components/list-panel/projects-list/projects-list.component.scss
@@ -420,6 +420,17 @@
   height: 20px;
 }
 
+.spinner-container {
+  position: absolute;
+  bottom: 100px;
+  left: 320px;
+  z-index: 10;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  pointer-events: none;
+}
+
 ::ng-deep .mat-expansion-panel-body {
   padding: 0 10px 16px !important;
 }

--- a/client/wfprev-war/src/main/angular/src/app/components/list-panel/projects-list/projects-list.component.spec.ts
+++ b/client/wfprev-war/src/main/angular/src/app/components/list-panel/projects-list/projects-list.component.spec.ts
@@ -1175,12 +1175,11 @@ describe('ProjectsListComponent', () => {
 
     const mockEl = {
       nativeElement: {
-        getAttribute: (attr: string) => (attr === 'data-guid' ? 'guid-123' : null),
+        dataset: { guid: 'guid-123' },
         scrollIntoView: scrollSpy,
         classList: { add: addClassSpy },
       },
     };
-
     const queryList = new QueryList<ElementRef>();
     queryList.reset([mockEl as unknown as ElementRef]);
     component.panelElements = queryList;

--- a/client/wfprev-war/src/main/angular/src/app/components/list-panel/projects-list/projects-list.component.spec.ts
+++ b/client/wfprev-war/src/main/angular/src/app/components/list-panel/projects-list/projects-list.component.spec.ts
@@ -1199,4 +1199,78 @@ describe('ProjectsListComponent', () => {
     expect(scrollSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
     expect(addClassSpy).toHaveBeenCalledWith('selected-project');
   }));
+
+  describe('addProjectToDisplayedList', () => {
+    let detectChangesSpy: jasmine.Spy;
+    let updateDisplayedProjectsSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      detectChangesSpy = spyOn((component as any).cdr, 'detectChanges');
+      updateDisplayedProjectsSpy = spyOn(component.sharedService, 'updateDisplayedProjects');
+    });
+
+    it('should add a new project when not already present', () => {
+      component.displayedProjects = [
+        { projectGuid: 'existing', projectName: 'A Project' }
+      ];
+      const newProject = { projectGuid: 'new', projectName: 'B Project' };
+
+      (component as any).addProjectToDisplayedList(newProject);
+
+      expect(component.displayedProjects.length).toBe(2);
+      expect(component.displayedProjects.some(p => p.projectGuid === 'new')).toBeTrue();
+      expect(updateDisplayedProjectsSpy).toHaveBeenCalledWith(component.displayedProjects);
+      expect(component.totalItems).toBe(2);
+      expect(detectChangesSpy).toHaveBeenCalled();
+    });
+
+    it('should not add if project already exists', () => {
+      component.displayedProjects = [{ projectGuid: 'dup', projectName: 'Same Project' }];
+      const newProject = { projectGuid: 'dup', projectName: 'Same Project' };
+
+      (component as any).addProjectToDisplayedList(newProject);
+
+      expect(component.displayedProjects.length).toBe(1);
+      expect(updateDisplayedProjectsSpy).not.toHaveBeenCalled();
+    });
+
+    it('should sort ascending when selectedSort is "ascending"', () => {
+      component.selectedSort = 'ascending';
+      component.displayedProjects = [
+        { projectGuid: '1', projectName: 'Z Project' }
+      ];
+      const newProject = { projectGuid: '2', projectName: 'A Project' };
+
+      (component as any).addProjectToDisplayedList(newProject);
+
+      expect(component.displayedProjects[0].projectName).toBe('A Project');
+    });
+
+    it('should sort descending when selectedSort is "descending"', () => {
+      component.selectedSort = 'descending';
+      component.displayedProjects = [
+        { projectGuid: '1', projectName: 'A Project' }
+      ];
+      const newProject = { projectGuid: '2', projectName: 'Z Project' };
+
+      (component as any).addProjectToDisplayedList(newProject);
+
+      expect(component.displayedProjects[0].projectName).toBe('Z Project');
+    });
+
+    it('should not sort if selectedSort is empty', () => {
+      component.selectedSort = '';
+      component.displayedProjects = [
+        { projectGuid: '1', projectName: 'B Project' }
+      ];
+      const newProject = { projectGuid: '2', projectName: 'A Project' };
+
+      (component as any).addProjectToDisplayedList(newProject);
+
+      // Should just append, not reorder
+      expect(component.displayedProjects[0].projectName).toBe('B Project');
+      expect(component.displayedProjects[1].projectName).toBe('A Project');
+    });
+  });
+
 });

--- a/client/wfprev-war/src/main/angular/src/app/components/list-panel/projects-list/projects-list.component.ts
+++ b/client/wfprev-war/src/main/angular/src/app/components/list-panel/projects-list/projects-list.component.ts
@@ -281,11 +281,14 @@ export class ProjectsListComponent implements OnInit {
 
   onScroll(event: Event): void {
     const target = event.target as HTMLElement;
-
-    const atBottom =
-      target.scrollHeight - target.scrollTop <= target.clientHeight + 50; // 50px threshold
-
-    if (atBottom && !this.isLoading && this.hasMore) {
+  
+    const scrollPosition = target.scrollTop + target.clientHeight;
+    const middleThreshold = target.scrollHeight / 2;
+  
+    // trigger load when user passes halfway point
+    const atMiddle = scrollPosition >= middleThreshold;
+  
+    if (atMiddle && !this.isLoading && this.hasMore) {
       this.loadProjects(false);
     }
   }

--- a/client/wfprev-war/src/main/angular/src/app/components/list-panel/projects-list/projects-list.component.ts
+++ b/client/wfprev-war/src/main/angular/src/app/components/list-panel/projects-list/projects-list.component.ts
@@ -95,7 +95,7 @@ export class ProjectsListComponent implements OnInit {
       this.cdr.detectChanges();
       setTimeout(() => {
         const element = this.panelElements?.find(
-          el => el.nativeElement.getAttribute('data-guid') === project.projectGuid
+          el => el.nativeElement.dataset.guid === project.projectGuid
         );
 
         if (element) {
@@ -234,17 +234,20 @@ export class ProjectsListComponent implements OnInit {
     if (this.isLoading || !this.hasMore) return;
     this.isLoading = true;
     const filters = this.sharedService.currentFilters || {};
+    
+    let sortBy: string | undefined;
+    let sortDirection: string | undefined;
 
-    const sortBy =
-      this.selectedSort === 'ascending' || this.selectedSort === 'descending'
-        ? 'projectName'
-        : undefined;
-    const sortDirection =
-      this.selectedSort === 'ascending'
-        ? 'asc'
-        : this.selectedSort === 'descending'
-        ? 'desc'
-        : undefined;
+    if (this.selectedSort === 'ascending') {
+      sortBy = 'projectName';
+      sortDirection = 'asc';
+    } else if (this.selectedSort === 'descending') {
+      sortBy = 'projectName';
+      sortDirection = 'desc';
+    } else {
+      sortBy = undefined;
+      sortDirection = undefined;
+    }
 
     this.projectService
       .getFeatures(filters, this.pageNumber, this.pageRowCount, sortBy, sortDirection)
@@ -258,7 +261,7 @@ export class ProjectsListComponent implements OnInit {
             (p, idx, self) =>
               p?.projectGuid && idx === self.findIndex(other => other.projectGuid === p.projectGuid)
           );
-          const sorted = deduped.sort((a, b) => a.projectName.localeCompare(b.projectName));
+          const sorted = [...deduped].sort((a, b) => a.projectName.localeCompare(b.projectName));
           this.allProjects = sorted
           this.displayedProjects = sorted;
           this.sharedService.updateDisplayedProjects(sorted);
@@ -432,7 +435,6 @@ export class ProjectsListComponent implements OnInit {
         });
       };
 
-      const self = this;
 
       // Helper function to generate random polygon points. This will be replaced by /features endpoint in API
       const generatePolygonPoints = (
@@ -443,7 +445,7 @@ export class ProjectsListComponent implements OnInit {
         const points = [];
         for (let i = 0; i < 50; i++) {
           const angle = (i / 50) * Math.PI * 2; // Angle in radians
-          const randomFactor = self.getSecureRandomNumber(); // Secure random value
+          const randomFactor = this.getSecureRandomNumber(); // Secure random value
           const offset = radius + randomFactor * variance - variance / 2; // Randomize radius
           const lat = center.latitude + offset * Math.sin(angle) / 111; // Approx 111 km per degree latitude
           const lng = center.longitude + offset * Math.cos(angle) / (111 * Math.cos(center.latitude * (Math.PI / 180)));

--- a/client/wfprev-war/src/main/angular/src/app/components/models.ts
+++ b/client/wfprev-war/src/main/angular/src/app/components/models.ts
@@ -203,6 +203,16 @@ export interface ProjectFile {
 
 export interface FeaturesResponse {
   projects?: ProjectExtended[];
+  currentPage?: number;
+  pageSize?: number;
+  totalItems?: number;
+  totalPages?: number;
+}
+
+export interface ProjectLocation {
+  projectGuid?: string
+  latitude?: number;
+  longitude?: number
 }
 
 export interface ProjectExtended extends Project {

--- a/client/wfprev-war/src/main/angular/src/app/components/resizable-panel/resizable-panel.component.html
+++ b/client/wfprev-war/src/main/angular/src/app/components/resizable-panel/resizable-panel.component.html
@@ -1,5 +1,5 @@
 <div class="resizable-panel">
-  <div class="scrollable-content">
+  <div class="scrollable-content" (scroll)="onParentScroll($event)">
     <wfprev-projects-list #projectList></wfprev-projects-list>
   </div>
 </div>

--- a/client/wfprev-war/src/main/angular/src/app/components/resizable-panel/resizable-panel.component.spec.ts
+++ b/client/wfprev-war/src/main/angular/src/app/components/resizable-panel/resizable-panel.component.spec.ts
@@ -116,4 +116,15 @@ describe('ResizablePanelComponent', () => {
     expect(component.selectedTabIndex).toBe(2); // Check updated tab index
   });
 
+  it('should delegate scroll event to projectList.onScroll', () => {
+    component.projectList = {
+      onScroll: jasmine.createSpy('onScroll')
+    } as any;
+
+    const mockEvent = new Event('scroll');
+
+    component.onParentScroll(mockEvent);
+
+    expect(component.projectList.onScroll).toHaveBeenCalledWith(mockEvent);
+  });
 });

--- a/client/wfprev-war/src/main/angular/src/app/components/resizable-panel/resizable-panel.component.ts
+++ b/client/wfprev-war/src/main/angular/src/app/components/resizable-panel/resizable-panel.component.ts
@@ -32,4 +32,8 @@ export class ResizablePanelComponent {
   selectTab(index: number): void {
     this.selectedTabIndex = index;
   }
+
+  onParentScroll(event: Event) {
+    this.projectList.onScroll(event);
+  }
 }

--- a/client/wfprev-war/src/main/angular/src/app/services/project-services.spec.ts
+++ b/client/wfprev-war/src/main/angular/src/app/services/project-services.spec.ts
@@ -1036,4 +1036,78 @@ describe('ProjectService', () => {
     req.flush('Error', { status: 500, statusText: 'Server Error' });
   });
 
+    it('should fetch a feature by projectGuid and return the first embedded project', () => {
+      const projectGuid = 'project-guid-123';
+      const mockProject: Project = {
+        projectGuid,
+        projectName: 'Feature Project',
+        bcParksRegionOrgUnitId: 1,
+        bcParksSectionOrgUnitId: 2,
+        closestCommunityName: 'Community',
+        fireCentreOrgUnitId: 3,
+        forestDistrictOrgUnitId: 4,
+        forestRegionOrgUnitId: 5,
+        isMultiFiscalYearProj: false,
+        programAreaGuid: 'program-guid',
+        projectDescription: 'Test description',
+        projectLead: 'Lead',
+        projectLeadEmailAddress: 'lead@example.com',
+        projectNumber: 42,
+        siteUnitName: 'Site',
+        totalActualAmount: 100,
+        totalAllocatedAmount: 100,
+        totalFundingRequestAmount: 100,
+        totalPlannedCostPerHectare: 10,
+        totalPlannedProjectSizeHa: 20
+      };
+
+      const mockResponse = {
+        _embedded: { project: [mockProject] }
+      };
+
+      service.getFeatureByProjectGuid(projectGuid).subscribe(result => {
+        expect(result).toEqual(mockProject);
+      });
+
+      const req = httpMock.expectOne((request) => {
+        return request.url === 'http://mock-api.com/wfprev-api/features' &&
+              request.params.get('projectGuid') === projectGuid;
+      });
+
+      expect(req.request.method).toBe('GET');
+      expect(req.request.headers.get('Authorization')).toBe('Bearer mock-token');
+      req.flush(mockResponse);
+    });
+
+    it('should return null if no project found in embedded', () => {
+      const projectGuid = 'nonexistent-guid';
+      const mockResponse = { _embedded: { project: [] } };
+
+      service.getFeatureByProjectGuid(projectGuid).subscribe(result => {
+        expect(result).toBeNull();
+      });
+
+      const req = httpMock.expectOne(
+        r => r.url === 'http://mock-api.com/wfprev-api/features'
+      );
+      req.flush(mockResponse);
+    });
+
+    it('should handle error when fetching feature by projectGuid', () => {
+      const projectGuid = 'error-guid';
+
+      service.getFeatureByProjectGuid(projectGuid).subscribe({
+        next: () => fail('Should have failed'),
+        error: (err) => {
+          expect(err.message).toBe('Failed to fetch feature by projectGuid');
+        }
+      });
+
+      const req = httpMock.expectOne(
+        r => r.url === 'http://mock-api.com/wfprev-api/features'
+      );
+      req.flush('Error', { status: 500, statusText: 'Server Error' });
+    });
+
+
 });

--- a/client/wfprev-war/src/main/angular/src/app/services/shared-service.spec.ts
+++ b/client/wfprev-war/src/main/angular/src/app/services/shared-service.spec.ts
@@ -171,4 +171,50 @@ describe('SharedService', () => {
     service.triggerMapCommand('open', testProject);
   });
 
+  it('should return the current filters via currentFilters getter', () => {
+    const testFilters = { region: 'South', type: 'Forest' };
+    service.updateFilters(testFilters);
+    expect(service.currentFilters).toEqual(testFilters);
+  });
+
+  it('should return the current displayed projects via currentDisplayedProjects getter', () => {
+    const testProjects: Project[] = [
+      {
+        bcParksRegionOrgUnitId: 10,
+        bcParksSectionOrgUnitId: 110,
+        closestCommunityName: 'Community X',
+        fireCentreOrgUnitId: 210,
+        forestDistrictOrgUnitId: 310,
+        forestRegionOrgUnitId: 410,
+        isMultiFiscalYearProj: false,
+        programAreaGuid: 'program-guid-x',
+        projectDescription: 'Description X',
+        projectGuid: 'project-guid-x',
+        projectLead: 'Lead X',
+        projectLeadEmailAddress: 'leadx@example.com',
+        projectName: 'Project X',
+        projectNumber: 1010,
+        siteUnitName: 'Site X',
+        totalActualAmount: 1000,
+        totalAllocatedAmount: 1500,
+        totalFundingRequestAmount: 2000,
+        totalPlannedCostPerHectare: 100,
+        totalPlannedProjectSizeHa: 10,
+        latitude: 49.5,
+        longitude: -123.5
+      }
+    ];
+
+    service.updateDisplayedProjects(testProjects);
+    expect(service.currentDisplayedProjects).toEqual(testProjects);
+  });
+
+  it('should emit undefined when selectProject is called without arguments', (done) => {
+    service.selectedProject$.subscribe((project) => {
+      expect(project).toBeUndefined();
+      done();
+    });
+    service.selectProject();
+  });
+
 });

--- a/client/wfprev-war/src/main/angular/src/app/services/shared-service.ts
+++ b/client/wfprev-war/src/main/angular/src/app/services/shared-service.ts
@@ -24,11 +24,19 @@ export class SharedService {
     this.displayedProjectsSource.next(projects);
   }
 
-  selectProject(project?: Project) {
-    this.selectedProjectSubject.next(project);
+  selectProject(project?: Partial<Project>) {
+    this.selectedProjectSubject.next(project as Project);
   }
 
   triggerMapCommand(action: 'open' | 'close', project: Project) {
     this._mapCommand$.next({ action, project });
+  }
+
+  get currentFilters(): any {
+    return this.filtersSource.getValue();
+  }
+
+  get currentDisplayedProjects(): Project[] {
+    return this.displayedProjectsSource.getValue();
   }
 }


### PR DESCRIPTION
https://apps.nrs.gov.bc.ca/int/jira/browse/WFPREV-677
https://apps.nrs.gov.bc.ca/int/jira/browse/WFPREV-614
map load all (filter applies) , list load first 20. <img width="2540" height="1300" alt="image" src="https://github.com/user-attachments/assets/86419cf1-23b8-4f14-b6f5-a500ebeacd5b" />
Spinner display when list is loading next page on scroll 
<img width="719" height="1215" alt="image" src="https://github.com/user-attachments/assets/87ae29b7-8f06-4722-b63d-7e5d35e8caa3" />
Auto scroll to the project in the list on clicking the map pin, If not existed yet, add the selected project then scrolled to it 
<img width="2544" height="1348" alt="image" src="https://github.com/user-attachments/assets/b1d2b86e-a321-4636-8337-d0b291892624" />

